### PR TITLE
Drop unnecessary dependencies

### DIFF
--- a/UM2N/__init__.py
+++ b/UM2N/__init__.py
@@ -1,5 +1,13 @@
 import os
 
+try:
+    import torch  # noqa
+except ImportError:
+    raise ImportError(
+        "PyTorch is required to use this package. Please install it first."
+        " Visit https://pytorch.org/get-started/locally/ for installation instructions."
+    )
+
 os.environ["OMP_NUM_THREADS"] = "1"
 
 from pkg_resources import DistributionNotFound, get_distribution  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "seaborn",
   # "torch", # NOTE: Should be installed beforehand
   "torch_geometric",
+  "wandb",
 ]
 authors = [
   {name = "Chunyang Wang"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,13 @@ dependencies = [
   "jupyter",
   "ipython",
   "matplotlib",
-  "meshio",
   "numpy",
   "pandas",
   "pytest",
   "rich",
   "ruff",
   "seaborn",
-  "tensorboardX",
-  "torch",
+  # "torch", # NOTE: Should be installed beforehand
   "torch_geometric",
 ]
 authors = [


### PR DESCRIPTION
Not strictly required for #57 but related work.

`meshio` and `tensorboardX` are never actually used in the code.

`torch` is used, but it should be installed for the desired architecture before attempting to install UM2N.