### PR TITLE
Add coverage to deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "coverage",
   "pytest",
   "ruff",
 ]


### PR DESCRIPTION
The UM2N regular CI is failing
https://github.com/mesh-adaptation/UM2N/actions/runs/13743708007/job/38436017628

Looks like we're missing some dependencies.